### PR TITLE
fix: fatal errors with severity 1

### DIFF
--- a/src/only-warn.js
+++ b/src/only-warn.js
@@ -15,6 +15,7 @@ function patch(LinterPrototype) {
     messages.forEach(message => {
       if (message.severity === 2) {
         message.severity = 1
+        message.fatal = false
       }
     })
     return messages

--- a/tests/only-warn.spec.js
+++ b/tests/only-warn.spec.js
@@ -7,9 +7,11 @@ describe('eslint-plugin-only-warn', () => {
     rules: { semi: 2 } // error on missing `;`
   }
   const sourceCode = 'var foo'
+
   it('should downgrade error(2) to warn(1)', () => {
     const messages = linter.verify(sourceCode, config)
     expect(messages[0].severity).toBe(1)
+    expect(messages[0].fatal).toBe(false)
   })
 
   it('can be temporarly disabled', () => {


### PR DESCRIPTION
`fatal` results in rules being treated as errors with severity 1.

![image](https://user-images.githubusercontent.com/5961873/73265526-25808d80-41fb-11ea-852d-71b2d3ad6329.png)
