### PR TITLE
Do not downgrade fatal error(2) to warn(1).

### DIFF
--- a/src/only-warn.js
+++ b/src/only-warn.js
@@ -13,7 +13,7 @@ function patch(LinterPrototype) {
   LinterPrototype.verify = function () {
     const messages = LinterPrototype[unpatchedVerify].apply(this, arguments)
     messages.forEach((message) => {
-      if (message.severity === 2) {
+      if (!message.fatal && message.severity === 2) {
         message.severity = 1
       }
     })

--- a/tests/only-warn.spec.js
+++ b/tests/only-warn.spec.js
@@ -12,6 +12,13 @@ describe('eslint-plugin-only-warn', () => {
     expect(messages[0].severity).toBe(1)
   })
 
+  const sourceCodeFatalError = 'var foo = ( => {}'
+  it('should not downgrade fatal error(2)', () => {
+    const messages = linter.verify(sourceCodeFatalError, config)
+    expect(messages[0].fatal).toBe(true)
+    expect(messages[0].severity).toBe(2)
+  })
+
   it('can be temporarly disabled', () => {
     disable()
     const messages1 = linter.verify(sourceCode, config)


### PR DESCRIPTION
Hi, this plugin is very useful to me.

I think fatal error should still display as error in code editor, it should looks different to warn, let developer to fix it asap.