### PR TITLE
fsd related warns

### DIFF
--- a/src/only-warn.js
+++ b/src/only-warn.js
@@ -12,10 +12,10 @@ function patch(LinterPrototype) {
   LinterPrototype[unpatchedVerify] = LinterPrototype.verify
   LinterPrototype.verify = function () {
     const messages = LinterPrototype[unpatchedVerify].apply(this, arguments)
-    const featureSlisedConfig = arguments?.[1]?.filter(a => a?.filePath?.includes('feature-sliced'))
+    const featureSlicedConfig = arguments?.[1]?.filter(a => a?.filePath?.includes('feature-sliced'))
     messages.forEach((message) => {
-      const featureSlisedRelated = featureSlisedConfig.some(c => c?.rules && Object.keys(c.rules).some(rule => message.ruleId == rule))
-      if (!message.fatal && message.severity === 2 && featureSlisedRelated) {
+      const featureSlicedRelated = featureSlicedConfig.some(c => c?.rules && Object.keys(c.rules).some(rule => message.ruleId == rule))
+      if (!message.fatal && message.severity === 2 && featureSlicedRelated) {
         message.severity = 1
       }
     })

--- a/src/only-warn.js
+++ b/src/only-warn.js
@@ -12,11 +12,14 @@ function patch(LinterPrototype) {
   LinterPrototype[unpatchedVerify] = LinterPrototype.verify
   LinterPrototype.verify = function () {
     const messages = LinterPrototype[unpatchedVerify].apply(this, arguments)
+    const featureSlisedConfig = arguments?.[1]?.filter(a => a?.filePath?.includes('feature-sliced'))
     messages.forEach((message) => {
-      if (!message.fatal && message.severity === 2) {
+      const featureSlisedRelated = featureSlisedConfig.some(c => c?.rules && Object.keys(c.rules).some(rule => message.ruleId == rule))
+      if (!message.fatal && message.severity === 2 && featureSlisedRelated) {
         message.severity = 1
       }
     })
+
     return messages
   }
 }


### PR DESCRIPTION
I have pre-commit hook that runs eslint.  We are migrating to [FSD](https://feature-sliced.design/) incrementally, so i need only to warn FSD related errors. Here's my quick code. I think, you can extend your plugin functionality