### PR TITLE
Add TypeScript type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "type": "commonjs",
   "main": "src/only-warn.js",
+  "types": "src/only-warn.d.ts",
   "prettier": {},
   "scripts": {
     "lint": "prettier --check . && eslint .",

--- a/src/only-warn.d.ts
+++ b/src/only-warn.d.ts
@@ -1,0 +1,2 @@
+export function enable(): void;
+export function disable(): void;


### PR DESCRIPTION
## Summary

- Add `src/only-warn.d.ts` with types for the `enable()` and `disable()` exports
- Add `"types"` field to `package.json`

This lets TypeScript consumers import the package without needing a custom `declare module 'eslint-plugin-only-warn'` stub.

Closes #16

## Test plan

- [x] Verify `src/only-warn.d.ts` exports match the runtime exports in `src/only-warn.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)